### PR TITLE
fix: add support for UTF-8 and Unicode in guac.Parse

### DIFF
--- a/instruction_test.go
+++ b/instruction_test.go
@@ -5,6 +5,37 @@ import (
 	"time"
 )
 
+func TestParse(t *testing.T) {
+	t.Run("OKWithUnicode", func(t *testing.T) {
+		valid := []byte("4.name,7.rocket🚀;")
+
+		if instr, err := Parse(valid); err != nil {
+			t.Fatal(err)
+		} else if got, want := len(instr.Args), 1; got != want {
+			t.Fatalf("Args=%v, want %v", got, want)
+		} else if got, want := instr.Opcode, "name"; got != want {
+			t.Fatalf("Opcode=%v, want %v", got, want)
+		}
+	})
+
+	t.Run("ErrorInvalidLength", func(t *testing.T) {
+		invalid := []byte("5.name,7.rocket*;")
+
+		if _, err := Parse(invalid); err == nil {
+			t.Fatal("expected error")
+		} else if err.Error() != "guac.Parse: wrong pattern instruction." {
+			t.Fatalf("unexpected error: %#v", err.Error())
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		invalid := []byte("4.name")
+		if _, err := Parse(invalid); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
 func TestInstruction_String(t *testing.T) {
 	ins := NewInstruction("select", "hi", "hello", "asdf")
 	if ins.String() != "6.select,2.hi,5.hello,4.asdf;" {


### PR DESCRIPTION
This commit adds support for UTF-8 and Unicode in the guac.Parse func.
We also check for lengths before accessing the data buffer array.

In this commit we also add some tests to cover these edge cases.