### PR TITLE
Configurable guacd address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # guac
 
-A port of the [Apache Guacamole client](https://github.com/apache/guacamole-client) to Go. 
+A port of the [Apache Guacamole client](https://github.com/apache/guacamole-client) to Go.
 
 Apache Guacamole provides access to your desktop using remote desktop protocols in your web browser without any plugins.
 
@@ -22,7 +22,12 @@ Next run the example main:
 go run cmd/guac/guac.go
 ```
 
-Now you can connect with [the example Vue app](https://github.com/wwt/guac-vue)
+Now you can connect with [the example Vue app](https://github.com/wwt/guac-vue).  By default guac will try to connect to a guacd instance at `127.0.0.1:4822`.  If you need to configure something different, you can do so by configuring environment variables; see the configurable parameters below.
+
+## Configurable parameters
+| Environment Variable | Description                                     | Default Value  | Required? |
+| -------------------- | ----------------------------------------------- | -------------- | ----------|
+| `GUACD_ADDRESS`      | The address and port that guacd is listening on | 127.0.0.1:4822 | No        |
 
 ## Acknowledgements
 

--- a/cmd/guac/guac.go
+++ b/cmd/guac/guac.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -15,13 +15,16 @@ import (
 )
 
 var (
-	guacdAddrFlg = flag.String("guacd-address", "127.0.0.1:4822", "Address and port of guacd in the format '127.0.0.1:4822'")
+	guacdAddr string
 )
 
 func main() {
-	flag.Parse()
-
 	logrus.SetLevel(logrus.DebugLevel)
+
+	guacdAddr = "127.0.0.1:4822"
+	if os.Getenv("GUACD_ADDRESS") != "" {
+		guacdAddr = os.Getenv("GUACD_ADDRESS")
+	}
 
 	servlet := guac.NewServer(DemoDoConnect)
 	wsServer := guac.NewWebsocketServer(DemoDoConnect)
@@ -123,7 +126,7 @@ func DemoDoConnect(request *http.Request) (guac.Tunnel, error) {
 	config.AudioMimetypes = []string{"audio/L16", "rate=44100", "channels=2"}
 
 	logrus.Debug("Connecting to guacd")
-	addr, err := net.ResolveTCPAddr("tcp", *guacdAddrFlg)
+	addr, err := net.ResolveTCPAddr("tcp", guacdAddr)
 	if err != nil {
 		logrus.Errorln("error resolving guacd address", err)
 		return nil, err

--- a/cmd/guac/guac.go
+++ b/cmd/guac/guac.go
@@ -141,7 +141,10 @@ func DemoDoConnect(request *http.Request) (guac.Tunnel, error) {
 	if request.URL.Query().Get("uuid") != "" {
 		config.ConnectionID = request.URL.Query().Get("uuid")
 	}
-	logrus.Debugf("Starting handshake with %#v", config)
+
+	sanitisedCfg := config
+	sanitisedCfg.Parameters["password"] = "********"
+	logrus.Debugf("Starting handshake with %#v", sanitisedCfg)
 	err = stream.Handshake(config)
 	if err != nil {
 		return nil, err

--- a/cmd/guac/guac.go
+++ b/cmd/guac/guac.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -82,7 +82,7 @@ func DemoDoConnect(request *http.Request) (guac.Tunnel, error) {
 	var query url.Values
 	if request.URL.RawQuery == "connect" {
 		// http tunnel uses the body to pass parameters
-		data, err := ioutil.ReadAll(request.Body)
+		data, err := io.ReadAll(request.Body)
 		if err != nil {
 			logrus.Error("Failed to read body ", err)
 			return nil, err

--- a/cmd/guac/guac.go
+++ b/cmd/guac/guac.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -13,7 +14,13 @@ import (
 	"github.com/wwt/guac"
 )
 
+var (
+	guacdAddrFlg = flag.String("guacd-address", "127.0.0.1:4822", "Address and port of guacd in the format '127.0.0.1:4822'")
+)
+
 func main() {
+	flag.Parse()
+
 	logrus.SetLevel(logrus.DebugLevel)
 
 	servlet := guac.NewServer(DemoDoConnect)
@@ -116,7 +123,11 @@ func DemoDoConnect(request *http.Request) (guac.Tunnel, error) {
 	config.AudioMimetypes = []string{"audio/L16", "rate=44100", "channels=2"}
 
 	logrus.Debug("Connecting to guacd")
-	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:4822")
+	addr, err := net.ResolveTCPAddr("tcp", *guacdAddrFlg)
+	if err != nil {
+		logrus.Errorln("error resolving guacd address", err)
+		return nil, err
+	}
 
 	conn, err := net.DialTCP("tcp", nil, addr)
 	if err != nil {

--- a/cmd/guac/guac.go
+++ b/cmd/guac/guac.go
@@ -15,13 +15,12 @@ import (
 )
 
 var (
-	guacdAddr string
+	guacdAddr = "127.0.0.1:4822"
 )
 
 func main() {
 	logrus.SetLevel(logrus.DebugLevel)
 
-	guacdAddr = "127.0.0.1:4822"
 	if os.Getenv("GUACD_ADDRESS") != "" {
 		guacdAddr = os.Getenv("GUACD_ADDRESS")
 	}

--- a/cmd/guac/guac.go
+++ b/cmd/guac/guac.go
@@ -60,7 +60,7 @@ func main() {
 		}
 	})
 
-	logrus.Println("Serving on http://127.0.0.1:4567")
+	logrus.Println("Serving on http://0.0.0.0:4567")
 
 	s := &http.Server{
 		Addr:           "0.0.0.0:4567",


### PR DESCRIPTION
This set of changes do 4 things.

1. Allows for configuring the guacd address and port as an input flag.  Fixes #13 
2. Replaces a deprecated function call from the stdlib
3. Small correction to the log entry for starting the web server; 0.0.0.0 instead of 127.0.0.1.
4. Hides passwords in log entries; previously they were printed in plaintext which may be picked up by logging platforms and stored.