### PR TITLE
Allow for server to support TLS if desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,16 @@ Next run the example main:
 go run cmd/guac/guac.go
 ```
 
-Now you can connect with [the example Vue app](https://github.com/wwt/guac-vue).  By default guac will try to connect to a guacd instance at `127.0.0.1:4822`.  If you need to configure something different, you can do so by configuring environment variables; see the configurable parameters below.
+Now you can connect with [the example Vue app](https://github.com/wwt/guac-vue).  By default, guac will try to connect to a guacd instance at `127.0.0.1:4822`.  If you need to configure something different, you can do so by configuring environment variables; see the configurable parameters below.
+
+Guac listens on `http://0.0.0.0:4567`.  If you have a need for the connection to Guac to be secure, you will need to pass a certificate and keyfile to it using the `CERT_PATH` and `CERT_KEY_PATH` environment variables; it will then listen on `https://0.0.0.0:4567`.  The secure connection uses TLS 1.3.
 
 ## Configurable parameters
-| Environment Variable | Description                                     | Default Value  | Required? |
-| -------------------- | ----------------------------------------------- | -------------- | ----------|
-| `GUACD_ADDRESS`      | The address and port that guacd is listening on | 127.0.0.1:4822 | No        |
+| Environment Variable | Description                                                                                              | Default Value  | Required? |
+| -------------------- | -------------------------------------------------------------------------------------------------------- | -------------- | ----------|
+| `CERT_PATH`          | Full path, including filename, to a certificate file in order for guac to listen on HTTPS (TLS 1.3)      |                | No        |
+| `CERT_KEY_PATH`      | Full path, including filename, to the certificate keyfile in order for guac to listen on HTTPS (TLS 1.3) |                | No        |
+| `GUACD_ADDRESS`      | The address and port that guacd is listening on                                                          | 127.0.0.1:4822 | No        |
 
 ## Acknowledgements
 


### PR DESCRIPTION
It would be handy for the server to support TLS if whoever is running it so desires; this change allows that.

It is up to the operator to provide the certifcate and keyfile.